### PR TITLE
Test auto upload to bintray

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,12 +23,10 @@ images = [
 
 base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
 
-if (conan_pkg_channel == "stable" && env.BRANCH_NAME != "master") {
-  error("Only the master branch can create a package for the stable channel")
-}
-
-// Allow overwriting packages if this is not the stable channel
 if (conan_pkg_channel == "stable") {
+  if (env.BRANCH_NAME != "master") {
+    error("Only the master branch can create a package for the stable channel")
+  }
   conan_upload_flag = "--no-overwrite"
 } else {
   conan_upload_flag = ""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ project = "conan-librdkafka"
 
 conan_remote = "ess-dmsc-local"
 conan_user = "ess-dmsc"
-conan_pkg_channel = "upload-test"
+conan_pkg_channel = "testing"
 
 remote_upload_node = "centos7"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,23 +10,23 @@ images = [
   'centos7': [
     'name': 'essdmscdm/centos7-build-node:2.1.0',
     'sh': 'sh'
-  ]//,
-  // 'centos7-gcc6': [
-  //   'name': 'essdmscdm/centos7-gcc6-build-node:3.0.0 ',
-  //   'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
-  // ],
-  // 'debian9': [
-  // 'name': 'essdmscdm/debian9-build-node:2.0.0',
-  // 'sh': 'sh'
-  // ],
-  // 'fedora25': [
-  //   'name': 'essdmscdm/fedora25-build-node:2.0.0',
-  //   'sh': 'sh'
-  // ],
-  // 'ubuntu1804': [
-  //   'name': 'essdmscdm/ubuntu18.04-build-node:1.0.0',
-  //   'sh': 'sh'
-  // ]
+  ],
+  'centos7-gcc6': [
+    'name': 'essdmscdm/centos7-gcc6-build-node:3.0.0 ',
+    'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
+  ],
+  'debian9': [
+  'name': 'essdmscdm/debian9-build-node:2.0.0',
+  'sh': 'sh'
+  ],
+  'fedora25': [
+    'name': 'essdmscdm/fedora25-build-node:2.0.0',
+    'sh': 'sh'
+  ],
+  'ubuntu1804': [
+    'name': 'essdmscdm/ubuntu18.04-build-node:1.0.0',
+    'sh': 'sh'
+  ]
 ]
 
 base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
@@ -260,8 +260,8 @@ node {
     def image_key = x
     builders[image_key] = get_pipeline(image_key)
   }
-  // builders['macOS'] = get_macos_pipeline()
-  // builders['windows10'] = get_win10_pipeline()
+  builders['macOS'] = get_macos_pipeline()
+  builders['windows10'] = get_win10_pipeline()
   parallel builders
 
   // Delete workspace when build is done.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,7 +140,7 @@ def get_pipeline(image_key) {
         //       --remote ess-dmsc \
         //       ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}
         //   \""""
-        }  // stage
+        // }  // stage
       } finally {
         sh "docker stop ${container_name}"
         sh "docker rm -f ${container_name}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ def get_pipeline(image_key) {
           pkg_name_and_version = sh(
             script: """docker exec ${container_name} ${custom_sh} -c \"
                 cd ${project} &&
-                conan info . | awk -F'@' 'NR==1{print $1}'
+                conan info . | awk -F'@' 'NR==1{print \\\$1}'
               \"""",
             returnStdout: true
           ).trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,6 +133,7 @@ def get_pipeline(image_key) {
               --remote ${conan_remote} \
               ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}
           \""""
+        }  // stage
 
         // Upload to remote repository only once
         if (image_key == remote_upload_node) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,7 @@ def get_pipeline(image_key) {
         stage("${image_key}: Local upload") {
           sh """docker exec ${container_name} ${custom_sh} -c \"
             conan upload \
+              --all \
               --no-overwrite \
               --remote ${conan_remote} \
               ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}
@@ -140,7 +141,6 @@ def get_pipeline(image_key) {
           stage("${image_key}: Remote upload") {
             sh """docker exec ${container_name} ${custom_sh} -c \"
               conan upload \
-                --all \
                 --no-overwrite \
                 --remote ess-dmsc \
                 ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,8 +255,8 @@ node {
     def image_key = x
     builders[image_key] = get_pipeline(image_key)
   }
-  builders['macOS'] = get_macos_pipeline()
-  builders['windows10'] = get_win10_pipeline()
+  // builders['macOS'] = get_macos_pipeline()
+  // builders['windows10'] = get_win10_pipeline()
   parallel builders
 
   // Delete workspace when build is done.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,8 +125,6 @@ def get_pipeline(image_key) {
           ).trim()
         }  // stage
 
-        echo "${pkg_name_and_version}"
-
         stage("${image_key}: Local upload") {
           sh """docker exec ${container_name} ${custom_sh} -c \"
             conan upload \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,8 @@ def get_pipeline(image_key) {
               --build=outdated
           \""""
 
-          // Get package name and version
+          // Use arcane awk magic found on Stack Overflow to get package name
+          // and version from conanfile.py.
           pkg_name_and_version = sh(
             script: """docker exec ${container_name} ${custom_sh} -c \"
                 cd ${project} &&

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,7 +58,7 @@ class LibrdkafkaConan(ConanFile):
             self.folder_name = "librdkafka-{}".format(self.win32_sha)
             patch = os.path.join(self.source_folder, "files", self.win32_patch_name)
             tools.patch(base_path=self.folder_name, patch_file=patch)
-        
+
         files.mkdir("./{}/build".format(self.folder_name))
         with tools.chdir("./{}/build".format(self.folder_name)):
             cmake = CMake(self)
@@ -107,4 +107,4 @@ class LibrdkafkaConan(ConanFile):
         self.copy("LICENSE.*", src=self.folder_name)
 
     def package_info(self):
-        self.cpp_info.libs = ["rdkafka", "rdkafka++"]
+        self.cpp_info.libs = ["rdkafka", "rdkafka++", "error"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -107,4 +107,4 @@ class LibrdkafkaConan(ConanFile):
         self.copy("LICENSE.*", src=self.folder_name)
 
     def package_info(self):
-        self.cpp_info.libs = ["rdkafka", "rdkafka++", "error"]
+        self.cpp_info.libs = ["rdkafka", "rdkafka++"]

--- a/get_conan_pkg_name_and_version.sh
+++ b/get_conan_pkg_name_and_version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+conan info . | awk -F'@' 'NR==1{print $1}'


### PR DESCRIPTION
Automates package upload to Bintray. The `--no-overwrite` flag is used to prevent overwriting a version with a modified version of a package (both for recipes and binaries). Also dropped the _upload_conan_package.sh_ script, as having to update it in a separate repository and release a new build node version to have the changes available is not practical.